### PR TITLE
Fixes global property usage

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -494,13 +494,13 @@ public class PythonClientCodegen extends AbstractPythonCodegen {
         return apiFileFolder() + File.separator + toApiFilename(tag) + suffix;
     }
 
-    private void generateFiles(List<List<Object>> processTemplateToFileInfos, String skippedByOption) {
+    private void generateFiles(List<List<Object>> processTemplateToFileInfos, boolean shouldGenerate, String skippedByOption) {
         for (List<Object> processTemplateToFileInfo: processTemplateToFileInfos) {
             Map<String, Object> templateData = (Map<String, Object>) processTemplateToFileInfo.get(0);
             String templateName = (String) processTemplateToFileInfo.get(1);
             String outputFilename = (String) processTemplateToFileInfo.get(2);
             try {
-                processTemplateToFile(templateData, templateName, outputFilename, true, skippedByOption);
+                processTemplateToFile(templateData, templateName, outputFilename, shouldGenerate, skippedByOption);
             } catch (IOException e) {
                 LOGGER.error("Error when writing template file {}", e.toString());
             }
@@ -664,9 +664,11 @@ public class PythonClientCodegen extends AbstractPythonCodegen {
             outputFilename = packageFilename(Arrays.asList("apis", "paths", pathModule + ".py"));
             apisFiles.add(Arrays.asList(operationMap, "apis_path_module.handlebars", outputFilename));
         }
-        generateFiles(pathsFiles, CodegenConstants.APIS);
-        generateFiles(apisFiles, CodegenConstants.APIS);
-        generateFiles(testFiles, CodegenConstants.API_TESTS);
+        boolean shouldGenerateApis = (boolean) additionalProperties().get(CodegenConstants.GENERATE_APIS);
+        boolean shouldGenerateApiTests = (boolean) additionalProperties().get(CodegenConstants.GENERATE_API_TESTS);
+        generateFiles(pathsFiles, shouldGenerateApis, CodegenConstants.APIS);
+        generateFiles(apisFiles, shouldGenerateApis, CodegenConstants.APIS);
+        generateFiles(testFiles, shouldGenerateApiTests, CodegenConstants.API_TESTS);
     }
 
     /*

--- a/modules/openapi-json-schema-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-json-schema-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -21,13 +21,20 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.*;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PythonClientCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings("static-method")
 public class PythonClientTest {
@@ -116,4 +123,45 @@ public class PythonClientTest {
 
     }
 
+    @Test
+    public void testApiTestsNotGenerated() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+
+        Map<String, String> globalProperties = Collections.singletonMap("apiTests", "false");
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGlobalProperties(globalProperties)
+                .setGeneratorName("python")
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+        Assert.assertTrue(files.size() > 0);
+
+        Path pathThatShouldNotExist = output.toPath().resolve("openapi_client/test/test_paths");
+        Assert.assertFalse(Files.isDirectory(pathThatShouldNotExist));
+        output.deleteOnExit();
+    }
+
+    @Test
+    public void testApisNotGenerated() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+
+        Map<String, String> globalProperties = Collections.singletonMap("models", "");
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGlobalProperties(globalProperties)
+                .setGeneratorName("python")
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+        Assert.assertTrue(files.size() > 0);
+
+        Path pathThatShouldNotExist = output.toPath().resolve("openapi_client/paths");
+        Assert.assertFalse(Files.isDirectory(pathThatShouldNotExist));
+        output.deleteOnExit();
+    }
 }


### PR DESCRIPTION
Fixes global property usage
Endpoints + endpoint tests are generated based upon paths; there was a bug where the code did not know that it should not generate those files when apis or api tests were deactivated
This PR adds that needed context to control generation of those files
- Adds testApisNotGenerated + testApiTestsNotGenerated to verify the fix

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
