### PR TITLE
[BUG] [Python] Attribute error when using auth header

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/resources/python/api_client.handlebars
+++ b/modules/openapi-json-schema-generator/src/main/resources/python/api_client.handlebars
@@ -1047,7 +1047,7 @@ class ApiClient:
     ) -> urllib3.HTTPResponse:
 
         # header parameters
-        headers = headers or {}
+        headers = headers or HTTPHeaderDict()
         headers.update(self.default_headers)
         if self.cookie:
             headers['Cookie'] = self.cookie

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/api_client.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/api_client.py
@@ -1048,7 +1048,7 @@ class ApiClient:
     ) -> urllib3.HTTPResponse:
 
         # header parameters
-        headers = headers or {}
+        headers = headers or HTTPHeaderDict()
         headers.update(self.default_headers)
         if self.cookie:
             headers['Cookie'] = self.cookie

--- a/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/this_package/api_client.py
+++ b/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/this_package/api_client.py
@@ -1048,7 +1048,7 @@ class ApiClient:
     ) -> urllib3.HTTPResponse:
 
         # header parameters
-        headers = headers or {}
+        headers = headers or HTTPHeaderDict()
         headers.update(self.default_headers)
         if self.cookie:
             headers['Cookie'] = self.cookie

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -1048,7 +1048,7 @@ class ApiClient:
     ) -> urllib3.HTTPResponse:
 
         # header parameters
-        headers = headers or {}
+        headers = headers or HTTPHeaderDict()
         headers.update(self.default_headers)
         if self.cookie:
             headers['Cookie'] = self.cookie


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fix #19

Use HTTPHeaderDict() instead of dict.

For Python client generation @spacether 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
