### PR TITLE
[WIP] verifies docker publishing works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.6.3-jdk-11-openj9
 
-ENV GEN_DIR /opt/openapi-generator
+ENV GEN_DIR /opt/openapi-json-schema-generator
 WORKDIR ${GEN_DIR}
 VOLUME  ${MAVEN_HOME}/.m2/repository
 
@@ -11,20 +11,20 @@ COPY ./LICENSE ${GEN_DIR}
 COPY ./google_checkstyle.xml ${GEN_DIR}
 
 # Modules are copied individually here to allow for caching of docker layers between major.minor versions
-COPY ./modules/openapi-generator-gradle-plugin ${GEN_DIR}/modules/openapi-generator-gradle-plugin
-COPY ./modules/openapi-generator-maven-plugin ${GEN_DIR}/modules/openapi-generator-maven-plugin
-COPY ./modules/openapi-generator-online ${GEN_DIR}/modules/openapi-generator-online
-COPY ./modules/openapi-generator-cli ${GEN_DIR}/modules/openapi-generator-cli
-COPY ./modules/openapi-generator-core ${GEN_DIR}/modules/openapi-generator-core
-COPY ./modules/openapi-generator ${GEN_DIR}/modules/openapi-generator
+COPY ./modules/openapi-json-schema-generator-gradle-plugin ${GEN_DIR}/modules/openapi-json-schema-generator-gradle-plugin
+COPY ./modules/openapi-json-schema-generator-maven-plugin ${GEN_DIR}/modules/openapi-json-schema-generator-maven-plugin
+COPY ./modules/openapi-json-schema-generator-online ${GEN_DIR}/modules/openapi-json-schema-generator-online
+COPY ./modules/openapi-json-schema-generator-cli ${GEN_DIR}/modules/openapi-json-schema-generator-cli
+COPY ./modules/openapi-json-schema-generator-core ${GEN_DIR}/modules/openapi-json-schema-generator-core
+COPY ./modules/openapi-json-schema-generator ${GEN_DIR}/modules/openapi-json-schema-generator
 COPY ./pom.xml ${GEN_DIR}
 
 # Pre-compile openapi-generator-cli
-RUN mvn -am -pl "modules/openapi-generator-cli" package
+RUN mvn -am -pl "modules/openapi-json-schema-generator-cli" package
 
 # This exists at the end of the file to benefit from cached layers when modifying docker-entrypoint.sh.
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s /usr/local/bin/docker-entrypoint.sh /usr/local/bin/openapi-generator
+RUN ln -s /usr/local/bin/docker-entrypoint.sh /usr/local/bin/openapi-json-schema-generator
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: docker_build
+
+docker_build:
+	docker build -t spacether/openapi-json-schema-generator-cli_test:latest .
+
+docker_publish:
+	docker push spacether/openapi-json-schema-generator-cli_test:latest


### PR DESCRIPTION
Adds make commands to build and publish docker images
I plan to use github actions to do this for production
And the action should run when a release is created
This is a manual test to verify that the docker hub uploading is working
And that the image works correctly

## Todo
- install docker image from remote
- use it to generate a python client + inspect the output

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
